### PR TITLE
fix error message when code is invalid

### DIFF
--- a/services/mobileDistriTV/app/src/main/java/com/distritv/ui/home/DeviceInfoFragment.kt
+++ b/services/mobileDistriTV/app/src/main/java/com/distritv/ui/home/DeviceInfoFragment.kt
@@ -73,6 +73,8 @@ class DeviceInfoFragment : Fragment() {
     private fun progressBarObserver() {
         homeActivityViewModel.loading.observe(viewLifecycleOwner) { visible ->
             binding.progressBar.visibility = if (visible) View.VISIBLE else View.GONE
+            binding.registerButton.isEnabled = !visible
+            binding.tvCode.isEnabled = !visible
         }
     }
 

--- a/services/mobileDistriTV/app/src/main/java/com/distritv/ui/home/HomeViewModel.kt
+++ b/services/mobileDistriTV/app/src/main/java/com/distritv/ui/home/HomeViewModel.kt
@@ -49,6 +49,7 @@ class HomeViewModel(
                         sharedPreferences.addTvCode(code)
                         _isValid.postValue(true)
                     } else {
+                        _errorMessage.postValue(MSG_TV_CODE_INVALID)
                         _isValid.postValue(false)
                     }
                 }

--- a/services/mobileDistriTV/config.properties
+++ b/services/mobileDistriTV/config.properties
@@ -1,7 +1,6 @@
 # If built with debug build variant:
 base_url_debug=http://10.0.2.2/api/v1/
 #base_url_debug=http://10.0.2.2:3090/api/v1/
-#base_url_debug=https://pruebamrt3.free.beeceptor.com/
 
 # If built with release build variant:
 base_url_release=http://triactivesoft.ddns.net/api/v1/


### PR DESCRIPTION
- cuando se recibía desde el servidor que el codigo no era valido no se mostraba el mensaje de error.
- ahora se deshabilita el boton Registrar y el cuadro de texto mientras se espera respuesta del servidor.